### PR TITLE
fix: Parse Error in iOS Version Bumping

### DIFF
--- a/tagging/package.json
+++ b/tagging/package.json
@@ -15,9 +15,9 @@
     "@actions/core": "^1.5.0",
     "@actions/exec": "^1.1.1",
     "@actions/github": "^5.0.0",
+    "@mmbt/pbxproj-dom": "^1.2.1",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",
-    "pbxproj-dom": "^1.2.0",
     "plist": "^3.0.5"
   },
   "devDependencies": {

--- a/tagging/src/utils/native-versions.ts
+++ b/tagging/src/utils/native-versions.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import path from 'path';
 import fs from 'fs';
-import { Xcode } from 'pbxproj-dom/xcode';
+import { Xcode } from '@mmbt/pbxproj-dom/xcode';
 import plist from 'plist';
 import { uniq as unique, flattenDeep } from 'lodash';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -855,6 +855,11 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@mmbt/pbxproj-dom@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@mmbt/pbxproj-dom/-/pbxproj-dom-1.2.1.tgz#bc7e3c151764e377d7cce140789c6830b36a98e6"
+  integrity sha512-w8e5IDKvCkFlvh8Xc5ky/jdn6m76DTUR06j/ljHpyCZCxprSbXfAXshkBPNGnA5crU1OFgSrYInb94XYd9OEUA==
+
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
@@ -3198,11 +3203,6 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
-
-pbxproj-dom@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pbxproj-dom/-/pbxproj-dom-1.2.0.tgz#1cf4101163bd666eba9eb92a5b8f616ce824ea85"
-  integrity sha512-K2czrWqA68AR0q1UXz5EBi/zoxcljrkO4RSJX0jPnVn3iyE0HYnYOzaEEDYMpueczkT/Vtdm3SCc3NM+12kMaQ==
 
 picocolors@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Found errors in utilizing`pbxproj-dom` if the iOS native files contained any code that was not properly escaped. Recently another developer created a forked version of that project since their pull request was not merged into pbxproj-dom.
This PR addresses that parsing error by moving to the newly forked dependency. Previous to these changes I was patching the expo-modules-autolinking project, however after latest update, this no longer works without further change, wanted to resolve the root problem.

Tested this in my github actions by referencing my forked version.

Reference for more details: https://github.com/NativeScript/pbxproj-dom/pull/10

**Error prior to fork:**
![image](https://github.com/echobind/mobile-release-actions/assets/7119624/936813ce-fa49-4ef2-a0b8-ae67ae95e552)

**Successul Run from my fork:**
![image](https://github.com/echobind/mobile-release-actions/assets/7119624/8dcd8df0-ca95-4ad4-b198-e8562f8f6fb6)
